### PR TITLE
Changed libvirt-python to 7.10.0

### DIFF
--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -29,7 +29,7 @@ class VirtManager < Formula
 
   resource "libvirt-python" do
     url "https://libvirt.org/sources/python/libvirt-python-7.10.0.tar.gz"
-    sha256 "676c260ddb365120404e611a38c514045ef1af1a7fede15c1fc02d0f8241f696"
+    sha256 "267774bbdf99d47515274542880499437dc94ae291771f5663c62020a62da975"
   end
 
   resource "idna" do

--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -28,7 +28,7 @@ class VirtManager < Formula
   depends_on "vte3"
 
   resource "libvirt-python" do
-    url "https://libvirt.org/sources/python/libvirt-python-7.3.0.tar.gz"
+    url "https://libvirt.org/sources/python/libvirt-python-7.10.0.tar.gz"
     sha256 "676c260ddb365120404e611a38c514045ef1af1a7fede15c1fc02d0f8241f696"
   end
 


### PR DESCRIPTION
Changed libvirt-python to 7.10.0 in order to match libvirt 7.10.0, which is the current version in homebrew/core as of Jan 20, 2022.  With this change, the tap builds and runs fine on macOS Monterey.